### PR TITLE
SIMD runtime detection refactor

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -41,7 +41,6 @@ else
           }
           SRC
           $defs.push("-DENABLE_SIMD")
-          append_cflags('-mavx2')
         elsif have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
@@ -50,9 +49,10 @@ else
           }
           SRC
             $defs.push("-DENABLE_SIMD")
-            append_cflags('-mavx2')
         end
       end
+
+      have_header('cpuid.h')
   end
 
   create_header

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -31,9 +31,7 @@ else
         end
       elsif have_header('x86intrin.h')
         
-        # This is currently hardcoded to false as using m256 seems significantly slower on my machine.
-        # TODO make this configurable
-        if false && have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+        if have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
               __m256i test = _mm256_set1_epi8(32);
@@ -41,14 +39,16 @@ else
           }
           SRC
           $defs.push("-DENABLE_SIMD")
-        elsif have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+        end
+        
+        if have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
               __m128i test = _mm_set1_epi8(32);
               return 0;
           }
           SRC
-            $defs.push("-DENABLE_SIMD")
+            $defs.push("-DENABLE_SIMD") unless $defs.include?('-DENABLE_SIMD')
         end
       end
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -478,35 +478,12 @@ static void convert_UTF8_to_JSON_escape_table_sse(FBuffer *out_buffer, VALUE str
      * better than what is implemented here.
      */
 
-    // if (((unsigned long)str & 15) == 0) {
-    //     //printf("VALUE IS ALIGNED!\n");
-    // } else {
-    //     printf("VALUE IS NOT ALIGNED!\n");
-    // }
-
-    // Let's get to an aligned pointer.
-    // unsigned long skipped = 0;
-    // while (((unsigned long)(ptr+pos) & 15) && pos < len) {
-    //     unsigned char ch = ptr[pos];
-    //     unsigned char ch_len = escape_table[ch];
-    //     skipped++;
-    //     PROCESS_BYTE
-    // }
-
-    // if (skipped) {
-    //     printf("Skipped %ld bytes. Remaining: %ld\n", skipped, (len - skipped));
-    // }
-
     const __m128i lower_bound = _mm_set1_epi8(' '); 
     const __m128i backslash   = _mm_set1_epi8('\\');
     const __m128i dblquote    = _mm_set1_epi8('\"');
 
     while (pos+16 < len) {
-        // __m128i chunk         = _mm_lddqu_si128((__m128i const*)&ptr[pos]); // This allows unaligned loads. The aligned version may perform better.
         __m128i chunk         = _mm_loadu_si128((__m128i const*)&ptr[pos]);
-
-        // This is the aligned version. Benefit: 
-        // __m128i chunk         = _mm_load_si128((__m128i const*)&ptr[pos]);
         __m128i too_low       = _mm_cmplt_epu8(chunk, lower_bound);
         __m128i has_backslash = _mm_cmpeq_epi8(chunk, backslash);
         __m128i has_dblquote  = _mm_cmpeq_epi8(chunk, dblquote);

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -39,11 +39,11 @@ SIMD_Implementation find_simd_implementation() {
 #endif 
 
 SIMD_Implementation find_simd_implementation(void) {
-#if defined(__GNU_C__) || defined(__clang__)
 
-#ifdef __GNUC__
+#if defined(__GNUC__ ) || defined(__clang__)
+#ifdef __GNUC__ 
     __builtin_cpu_init();
-#endif /* __GNUC__ */
+#endif /* __GNUC__  */
 
 #ifdef HAVE_TYPE___M256I
     if(__builtin_cpu_supports("avx2")) {
@@ -55,7 +55,7 @@ SIMD_Implementation find_simd_implementation(void) {
     if (__builtin_cpu_supports("sse4.2")) {
         return SIMD_SSE4;
     }
-#endif /* __GNU_C__ || __clang__*/
+#endif /* __GNUC__ || __clang__*/
 
     return SIMD_NONE;
 }

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -1,13 +1,13 @@
 #include "extconf.h"
 
-#ifdef ENABLE_SIMD
-
 typedef enum {
     SIMD_NONE,
     SIMD_NEON,
-    SIMD_SSE4,
+    SIMD_SSE42,
     SIMD_AVX2
 } SIMD_Implementation;
+
+#ifdef ENABLE_SIMD
 
 #if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h>
@@ -53,7 +53,7 @@ SIMD_Implementation find_simd_implementation(void) {
 
     // TODO Revisit. I think the SSE version now only uses SSE2 instructions.
     if (__builtin_cpu_supports("sse4.2")) {
-        return SIMD_SSE4;
+        return SIMD_SSE42;
     }
 #endif /* __GNUC__ || __clang__*/
 

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -5,13 +5,14 @@
 typedef enum {
     SIMD_NONE,
     SIMD_NEON,
-    SIMD_SSE4_1,
+    SIMD_SSE4,
     SIMD_AVX2
 } SIMD_Implementation;
 
 #if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h>
 
+#define FIND_SIMD_IMPLEMENTATION_DEFINED 1
 SIMD_Implementation find_simd_implementation() {
     return SIMD_NEON;
 }
@@ -65,8 +66,13 @@ inline int smd_vec_all_zero(uint8x8_t vec) {
 #endif /* HAVE_TYPE_UINT8X16_T */
 #endif /* ARM Neon Support.*/
 
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+
+#define HAVE_SIMD_X86_64 1 
 #ifdef HAVE_X86INTRIN_H
 #include <x86intrin.h>
+
+#define HAVE_SIMD_X86_64 1
 
 #ifdef HAVE_TYPE___M256I
 
@@ -199,16 +205,36 @@ int simd_vec_all_zero(__m128i vec) {
 
 #endif /* HAVE_TYPE___M256 */
 
-SIMD_Implementation find_simd_implementation() {
-    /* IMPLEMENT THIS! */
+#ifdef HAVE_CPUID_H
+#define FIND_SIMD_IMPLEMENTATION_DEFINED 1
+
+#include <cpuid.h>
+#endif 
+
+SIMD_Implementation find_simd_implementation(void) {
+
+#ifdef __GNUC__
+    __builtin_cpu_init();
+#endif
+
+    // if(__builtin_cpu_supports("avx2")) {
+    //     printf("CPU supports AVX2!\n");
+    // }
+    
+    // TODO Revisit. I think the SSE version now only uses SSE2 instructions.
+    if (__builtin_cpu_supports("sse4.2")) {
+        return SIMD_SSE4;
+    } 
+    
     return SIMD_NONE;
 }
 
 #endif /* HAVE_X86INTRIN_H */
-#else
+#endif /* X86_64 Support */
+#endif /* ENABLE_SIMD */
 
-SIMD_Implementation find_simd_implementation() {
+#ifndef FIND_SIMD_IMPLEMENTATION_DEFINED
+SIMD_Implementation find_simd_implementation(void) {
     return SIMD_NONE;
 }
-
-#endif /* ENABLE_SIMD */
+#endif

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -20,48 +20,6 @@ SIMD_Implementation find_simd_implementation() {
 #define HAVE_SIMD_NEON 1
 
 #ifdef HAVE_TYPE_UINT8X16_T
-#define SIMD_VEC_STRIDE          16
-
-#define simd_vec_type            uint8x16_t
-#define simd_vec_from_byte       vdupq_n_u8
-#define simd_vec_load_from_mem   vld1q_u8
-#define simd_vec_to_memory       vst1q_u8
-#define simd_vec_eq              vceqq_u8
-#define simd_vec_lt              vcltq_u8
-#define simd_vec_gt              vcgtq_u8
-#define simd_vec_or              vorrq_u8
-#define simd_vec_and             vandq_u8
-#define simd_vec_max             vmaxvq_u8
-
-inline int simd_vec_any_set(uint8x16_t vec) {
-    return vmaxvq_u8(vec) != 0;
-}
-
-inline int simd_vec_all_zero(uint8x16_t vec) {
-    return vmaxvq_u8(vec) == 0;
-}
-
-#elif HAVE_TYPE_UINT8X8_T
-
-#define SIMD_VEC_STRIDE          8
-#define simd_vec_type            uint8x8_t
-#define simd_vec_from_byte       vdup_n_u8
-#define simd_vec_load_from_mem   vld1_u8
-#define simd_vec_to_memory       vst1_u8
-#define simd_vec_eq              vceq_u8
-#define simd_vec_lt              vclt_u8
-#define simd_vec_gt              vcgt_u8
-#define simd_vec_or              vorr_u8
-#define simd_vec_and             vand_u8
-#define simd_vec_max             vmaxv_u8
-
-inline int smd_vec_any_set(uint8x8_t vec) {
-    return vmaxv_u8(vec) != 0;
-}
-
-inline int smd_vec_all_zero(uint8x8_t vec) {
-    return vmaxv_u8(vec) == 0;
-}
 
 #endif /* HAVE_TYPE_UINT8X16_T */
 #endif /* ARM Neon Support.*/
@@ -74,137 +32,6 @@ inline int smd_vec_all_zero(uint8x8_t vec) {
 
 #define HAVE_SIMD_X86_64 1
 
-#ifdef HAVE_TYPE___M256I
-
-#define SIMD_VEC_STRIDE             32
-
-#define _mm256_cmpge_epu8(a, b) _mm256_cmpeq_epi8(_mm256_max_epu8(a, b), a)
-#define _mm256_cmple_epu8(a, b) _mm256_cmpge_epu8(b, a)
-#define _mm256_cmpgt_epu8(a, b) _mm256_xor_si256(_mm256_cmple_epu8(a, b), _mm256_set1_epi8(-1))
-#define _mm256_cmplt_epu8(a, b) _mm256_cmpgt_epu8(b, a)
-
-#define simd_vec_type                __m256i
-#define simd_vec_from_byte           _mm256_set1_epi8
-#define simd_vec_load_from_mem(x)    _mm256_loadu_si256((__m256i const*) x)
-#define simd_vec_to_memory(mem, vec) _mm256_storeu_si256((__m256i *) mem, (__m256i) vec)
-#define simd_vec_eq                  _mm256_cmpeq_epi8
-#define simd_vec_lt(a,b)             _mm256_cmplt_epu8(a, b)
-#define simd_vec_gt(a,b)             _mm256_cmpgt_epu8(a, b)
-#define simd_vec_or                  _mm256_or_si256
-#define simd_vec_and                 _mm256_and_si256
-#define simd_vec_max                 _mm256_max_epu8
-
-void print_simd_vec(simd_vec_type vec) {
-    alignas(32) unsigned char bytes[32];
-    _mm256_storeu_si256((__m256i *) bytes, vec);
-    printf("SIMD vector:\n\t[");
-    for(int i=0; i< 32; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-void print_simd_vec1(const char *prefix, simd_vec_type vec) {
-    alignas(32) unsigned char bytes[32];
-    _mm256_storeu_si256((__m256i *) bytes, vec);
-    printf("%s:\n\t[", prefix);
-    for(int i=0; i< 32; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-int simd_vec_any_set(__m256i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m256i zero = _mm256_setzero_si256();
-    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
-    int mask     = _mm256_movemask_epi8(cmp);
-    return mask != 0xFFFF;
-}
-
-int simd_vec_all_zero(__m256i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m256i zero = _mm256_setzero_si256();
-    __m256i cmp  = _mm256_cmpeq_epi8(vec, zero);
-    int mask     = _mm256_movemask_epi8(cmp);
-    return mask == 0xFFFF;
-}
-
-#elif HAVE_TYPE___M128I
-#define SIMD_VEC_STRIDE          16
-
-/*
- From: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#ig_expand=876,4329,7112,5801,3975,6546,4842,305,4293,6490,5869,4602,4329,4293,4329
-
-_mm_and_si128               SSE2
-_mm_cmpeq_epi8              SSE2
-_mm_lddqu_si128             SSE3
-_mm_max_epu8                SSE2
-_mm_max_epi8                SSE4.1
-_mm_movemask_epi8           SSE2
-_mm_or_si128                SSE2
-_mm_set1_epi8               SSE2
-_mm_setzero_si128           SSE2
-_mm_store_si128             SSE2
-_mm_storeu_si128            SSE2
-_mm_xor_si128               SSE2
-*/
-
-#define _mm_cmpge_epu8(a, b) _mm_cmpeq_epi8(_mm_max_epu8(a, b), a)
-#define _mm_cmple_epu8(a, b) _mm_cmpge_epu8(b, a)
-#define _mm_cmpgt_epu8(a, b) _mm_xor_si128(_mm_cmple_epu8(a, b), _mm_set1_epi8(-1))
-#define _mm_cmplt_epu8(a, b) _mm_cmpgt_epu8(b, a)
-
-#define simd_vec_type               __m128i
-#define simd_vec_from_byte          _mm_set1_epi8
-#define simd_vec_load_from_mem(x)   _mm_lddqu_si128((__m128i const*) x)
-#define simd_vec_to_memory(mem, vec) _mm_storeu_si128((__m128i *) mem, (__m128i) vec)
-#define simd_vec_eq                 _mm_cmpeq_epi8
-#define simd_vec_lt(a,b)            _mm_cmplt_epu8(a, b)
-#define simd_vec_gt(a,b)            _mm_cmpgt_epu8(a, b)
-#define simd_vec_or                 _mm_or_si128
-#define simd_vec_and                _mm_and_si128
-#define simd_vec_max                _mm_max_epi8
-
-
-
-void print_simd_vec(simd_vec_type vec) {
-    alignas(16) unsigned char bytes[16];
-    _mm_store_si128((__m128i *) bytes, vec);
-    printf("SIMD vector:\n\t[");
-    for(int i=0; i< 16; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-void print_simd_vec1(const char *prefix, simd_vec_type vec) {
-    alignas(16) unsigned char bytes[16];
-    _mm_store_si128((__m128i *) bytes, vec);
-    printf("%s:\n\t[", prefix);
-    for(int i=0; i< 16; i++) {
-        printf(" %02x ", bytes[i]);
-    }
-    printf("]\n");
-}
-
-int simd_vec_any_set(__m128i vec) {
-    // print_simd_vec1("simd_vec_any_set vec", vec);
-    __m128i zero = _mm_setzero_si128();
-    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
-    int mask     = _mm_movemask_epi8(cmp);
-    return mask != 0xFFFF;
-}
-
-int simd_vec_all_zero(__m128i vec) {
-    __m128i zero = _mm_setzero_si128();
-    __m128i cmp  = _mm_cmpeq_epi8(vec, zero);
-    int mask     = _mm_movemask_epi8(cmp);
-    return mask  == 0xFFFF;
-}
-
-#endif /* HAVE_TYPE___M256 */
-
 #ifdef HAVE_CPUID_H
 #define FIND_SIMD_IMPLEMENTATION_DEFINED 1
 
@@ -212,20 +39,24 @@ int simd_vec_all_zero(__m128i vec) {
 #endif 
 
 SIMD_Implementation find_simd_implementation(void) {
+#if defined(__GNU_C__) || defined(__clang__)
 
 #ifdef __GNUC__
     __builtin_cpu_init();
-#endif
+#endif /* __GNUC__ */
 
-    // if(__builtin_cpu_supports("avx2")) {
-    //     printf("CPU supports AVX2!\n");
-    // }
-    
+#ifdef HAVE_TYPE___M256I
+    if(__builtin_cpu_supports("avx2")) {
+        return SIMD_AVX2;
+    }
+#endif /* #ifdef HAVE_TYPE___M256I */
+
     // TODO Revisit. I think the SSE version now only uses SSE2 instructions.
     if (__builtin_cpu_supports("sse4.2")) {
         return SIMD_SSE4;
-    } 
-    
+    }
+#endif /* __GNU_C__ || __clang__*/
+
     return SIMD_NONE;
 }
 

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -424,6 +424,10 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["\\\\.(?i:gif|jpe?g|png)$"]'
     assert_equal json, generate(data)
     #
+    data = [ '\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)\\.(?i:gif|jpe?g|png)$' ]
+    json = '["\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)\\\\.(?i:gif|jpe?g|png)$"]'
+    assert_equal json, generate(data)
+    #
     data = [ '\\"' ]
     json = '["\\\\\""]'
     assert_equal json, generate(data)
@@ -432,8 +436,20 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["/"]'
     assert_equal json, generate(data)
     #
+    data = [ '////////////////////////////////////////////////////////////////////////////////////' ]
+    json = '["////////////////////////////////////////////////////////////////////////////////////"]'
+    assert_equal json, generate(data)
+    #
     data = [ '/' ]
     json = '["\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
+    data = [ '///////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
+    data = [ '///////////////////////////////////////////////////////' ]
+    json = '["\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/"]'
     assert_equal json, generate(data, :script_safe => true)
     #
     data = [ "\u2028\u2029" ]
@@ -444,8 +460,16 @@ class JSONGeneratorTest < Test::Unit::TestCase
     json = '["ABC \u2028 DEF \u2029 GHI"]'
     assert_equal json, generate(data, :script_safe => true)
     #
+    data = [ "ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI" ]
+    json = '["ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI ABC \u2028 DEF \u2029 GHI"]'
+    assert_equal json, generate(data, :script_safe => true)
+    #
     data = [ "/\u2028\u2029" ]
     json = '["\/\u2028\u2029"]'
+    assert_equal json, generate(data, :escape_slash => true)
+    #
+    data = [ "/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029/\u2028\u2029" ]
+    json = '["\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029\/\u2028\u2029"]'
     assert_equal json, generate(data, :escape_slash => true)
     #
     data = ['"']
@@ -459,6 +483,14 @@ class JSONGeneratorTest < Test::Unit::TestCase
     data = ["倩", "瀨"]
     json = '["倩","瀨"]'
     assert_equal json, generate(data, script_safe: true)
+    #
+    data = ["倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨", "倩", "瀨"]
+    json = '["倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨","倩","瀨"]'
+    assert_equal json, generate(data, script_safe: true)
+    #
+    data = '["This is a "test" of the emergency broadcast system."]'
+    json = "\"[\\\"This is a \\\"test\\\" of the emergency broadcast system.\\\"]\""
+    assert_equal json, generate(data)
   end
 
   def test_string_subclass


### PR DESCRIPTION
# Work In Progress

**NOTE** Still a lot of refactoring left to do.

Refactor to use runtime detection of the best algorithm.

Running under the Windows Subsystem for Linux on a Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz   2.59 GHz

```
== Encoding long string (124001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json     3.297k i/100ms
                  oj   881.000 i/100ms
Calculating -------------------------------------
                json     32.561k (± 6.0%) i/s   (30.71 μs/i) -    164.850k in   5.085033s
                  oj      8.862k (± 2.5%) i/s  (112.84 μs/i) -     44.931k in   5.073251s

Comparison:
                json:    32560.8 i/s
                  oj:     8862.3 i/s - 3.67x  slower
```

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json   102.000 i/100ms
                  oj    17.000 i/100ms
Calculating -------------------------------------
                json      1.126k (±10.7%) i/s  (888.06 μs/i) -      5.712k in   5.150838s
                  oj    188.422 (± 9.0%) i/s    (5.31 ms/i) -    935.000 in   5.009942s

Comparison:
                json:     1126.1 i/s
                  oj:      188.4 i/s - 5.98x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json   120.000 i/100ms
                  oj    19.000 i/100ms
Calculating -------------------------------------
                json      1.208k (± 3.0%) i/s  (827.74 μs/i) -      6.120k in   5.070336s
                  oj    187.077 (± 2.7%) i/s    (5.35 ms/i) -    950.000 in   5.081109s

Comparison:
                json:     1208.1 i/s
                  oj:      187.1 i/s - 6.46x  slower
```