### PR TITLE
SSE4.2 Lookup Table Kernel

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -31,7 +31,7 @@ else
         end
       elsif have_header('x86intrin.h')
         
-        if have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
+        if false && have_type('__m256i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-mavx2')
           #include <x86intrin.h>
           int main() {
               __m256i test = _mm256_set1_epi8(32);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -493,17 +493,6 @@ void convert_UTF8_to_JSON_simd_kernel_neon(FBuffer *out_buffer, const char * ptr
 #define _mm_cmpgt_epu8(a, b) _mm_xor_si128(_mm_cmple_epu8(a, b), _mm_set1_epi8(-1))
 #define _mm_cmplt_epu8(a, b) _mm_cmpgt_epu8(b, a)
 
-void print_simd_vec1(const char *prefix, __m128i vec) {
-    uint8_t r[16];
-    _mm_storeu_si128((__m128i *) r, vec);
-
-    printf("%s = [ ", prefix);
-    for(int i=0; i<16; i++) {
-        printf("%02x ", r[i]);
-    }
-    printf("]\n");
-}
-
 #ifdef __clang__
 __attribute__((target("sse4.2")))
 #endif /* __clang__ */


### PR DESCRIPTION
# Benchmarks

## SSE4.2 Rules Based Kernel
This is the existing implementation. It directly checks multiple conditions against a 16 byte chunk of data.

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json   110.000 i/100ms
                  oj    17.000 i/100ms
Calculating -------------------------------------
                json      1.112k (± 7.4%) i/s  (899.02 μs/i) -      5.610k in   5.073406s
                  oj    193.508 (± 4.7%) i/s    (5.17 ms/i) -    969.000 in   5.017873s

Comparison:
                json:     1112.3 i/s
                  oj:      193.5 i/s - 5.75x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json   101.000 i/100ms
                  oj    18.000 i/100ms
Calculating -------------------------------------
                json      1.140k (± 3.7%) i/s  (877.37 μs/i) -      5.757k in   5.058461s
                  oj    185.093 (± 6.5%) i/s    (5.40 ms/i) -    936.000 in   5.080750s

Comparison:
                json:     1139.8 i/s
                  oj:      185.1 i/s - 6.16x  slower
```

## SSE4.2 Lookup Table Based Kernel
This uses the `escape_table` to look up the correct action for each byte in the 16 byte chunk of data. If no actions are needed it skips to the next 16 byte chunk.

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json    73.000 i/100ms
                  oj    18.000 i/100ms
Calculating -------------------------------------
                json    725.505 (± 4.1%) i/s    (1.38 ms/i) -      3.650k in   5.042347s
                  oj    202.460 (± 3.5%) i/s    (4.94 ms/i) -      1.026k in   5.073307s

Comparison:
                json:      725.5 i/s
                  oj:      202.5 i/s - 3.58x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json    70.000 i/100ms
                  oj    19.000 i/100ms
Calculating -------------------------------------
                json    708.133 (± 2.8%) i/s    (1.41 ms/i) -      3.570k in   5.045727s
                  oj    200.301 (± 2.5%) i/s    (4.99 ms/i) -      1.007k in   5.030429s

Comparison:
                json:      708.1 i/s
                  oj:      200.3 i/s - 3.54x  slower
```