### PR TITLE
Use bit twiddling for JSON Generation

### DIFF
--- a/benchmark/encoder-simple.rb
+++ b/benchmark/encoder-simple.rb
@@ -55,4 +55,4 @@ def benchmark_encoding(benchmark_name, ruby_obj, check_expected: true, except: [
   puts
 end
 
-benchmark_encoding "long string", (["this is a test of the emergency broadcast system."*5]*500)
+benchmark_encoding "long string with accents", (["this is å test öf the émergéncy bröadcást system."*5]*500)

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -686,6 +686,114 @@ void convert_UTF8_to_JSON_simd_kernel_avx2(FBuffer *out_buffer, const char * ptr
 #endif /* x86_64 support */
 
 
+static void convert_UTF8_to_JSON_old_skool_simd(FBuffer *out_buffer, VALUE str, const unsigned char escape_table[256])
+{
+    const char *hexdig = "0123456789abcdef";
+    char scratch[12] = { '\\', 'u', 0, 0, 0, 0, '\\', 'u' };
+
+    const char *ptr = RSTRING_PTR(str);
+    unsigned long len = RSTRING_LEN(str);
+
+    unsigned long beg = 0, pos = 0;
+
+    // printf("\n");
+    // printf("sizeof uintptr_t: %lu", sizeof(uintptr_t));
+
+    if (escape_table != script_safe_escape_table) {
+// Taken from: https://github.com/ruby/ruby/blob/96a5da67864a15eea7b79e552c7684ddd182f76c/string.c#L671-L748
+// TODO revisit for the compiler version check
+
+// These macros from https://graphics.stanford.edu/~seander/bithacks.html
+# if SIZEOF_UINTPTR_T == 8
+#define hasless(x,n) (((x)-~0ULL/255*(n))&~(x)&~0ULL/255*128)
+#define haszero(v) (((v) - 0x0101010101010101ULL) & ~(v) & 0x8080808080808080ULL)
+# elif SIZEOF_UINTPTR_T == 4
+#define hasless(x,n) (((x)-~0UL/255*(n))&~(x)&~0UL/255*128)
+#define haszero(v) (((v) - 0x01010101UL) & ~(v) & 0x80808080UL)
+# else
+#  error "don't know what to do."
+#endif
+
+        /*
+        * Align the pointer to a sizeof(uintptr_t)-byte boundary.
+        * TODO: Use the same alignment technique as 
+        */
+        char *char_ptr;
+        for (char_ptr = (char *) ptr;
+        pos < len && (uintptr_t) char_ptr % sizeof (uintptr_t) != 0;
+        ) {
+            unsigned long start = pos;
+            char ch = *char_ptr;
+            unsigned char ch_len = escape_table[ch];
+            PROCESS_BYTE;
+            // This might process more than one byte. Ensure we increment char_ptr appropriately.
+            char_ptr += (pos - start);
+        }
+
+        uintptr_t maskDoubleQuote = '"' | '"' << 8;
+        uintptr_t maskForwardSlash = '\\' | '\\' << 8;
+        maskDoubleQuote |= maskDoubleQuote << 16;
+        maskForwardSlash |= maskForwardSlash << 16;
+#if SIZEOF_UINTPTR_T == 8
+        maskDoubleQuote |= maskDoubleQuote << 32;
+        maskForwardSlash |= maskForwardSlash << 32;
+#endif 
+        uintptr_t *lp = (uintptr_t *) char_ptr;
+
+        while (pos + sizeof(uintptr_t) < len) {
+            uintptr_t chunk = *lp;
+
+            uintptr_t tmp1 = chunk ^ maskDoubleQuote;
+            uintptr_t tmp2 = chunk ^ maskForwardSlash;
+
+            uintptr_t has_less_than_0x20 = hasless(chunk, ' ');
+            if (RB_UNLIKELY(has_less_than_0x20)) {
+                goto process_bytes;
+            }
+
+            uintptr_t haszero1 = haszero(tmp1);
+            if (RB_UNLIKELY(haszero1)) {
+                goto process_bytes;
+            }
+
+            uintptr_t haszero2 = haszero(tmp2);
+            if (RB_UNLIKELY(haszero2)) {
+                goto process_bytes;
+            }
+
+            lp++;
+            pos += sizeof(uintptr_t);
+            continue;
+
+process_bytes:
+            for(int i=0; i<sizeof(uintptr_t); i++) {
+                unsigned char ch = ptr[pos];
+                unsigned char ch_len = escape_table[ch];
+                /* JSON encoding */
+
+                PROCESS_BYTE;
+            }
+        }
+    }
+
+#undef hasless
+#undef haszero
+
+    while (pos < len) {
+        unsigned char ch = ptr[pos];
+        unsigned char ch_len = escape_table[ch];
+        /* JSON encoding */
+
+        PROCESS_BYTE;
+    }
+
+    if (beg < len) {
+        fbuffer_append(out_buffer, &ptr[beg], len - beg);
+    }
+
+    RB_GC_GUARD(str);
+}
+
 static void convert_UTF8_to_JSON(FBuffer *out_buffer, VALUE str, const unsigned char escape_table[256])
 {
     const char *hexdig = "0123456789abcdef";
@@ -2150,6 +2258,7 @@ void Init_generator(void)
 #endif /* HAVE_TYPE___M256I */
 #endif
         default:
-            convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON;
+            convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON_old_skool_simd;
+            // convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON;
     }
 }

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -686,7 +686,7 @@ void convert_UTF8_to_JSON_simd_kernel_avx2(FBuffer *out_buffer, const char * ptr
 #endif /* x86_64 support */
 
 
-static void convert_UTF8_to_JSON_old_skool_simd(FBuffer *out_buffer, VALUE str, const unsigned char escape_table[256])
+static void convert_UTF8_to_JSON_2(FBuffer *out_buffer, VALUE str, const unsigned char escape_table[256])
 {
     const char *hexdig = "0123456789abcdef";
     char scratch[12] = { '\\', 'u', 0, 0, 0, 0, '\\', 'u' };
@@ -2256,7 +2256,7 @@ void Init_generator(void)
 #endif /* HAVE_TYPE___M256I */
 #endif
         default:
-            convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON_old_skool_simd;
+            convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON_2;
             // convert_UTF8_to_JSON_impl = convert_UTF8_to_JSON;
     }
 }

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -491,6 +491,26 @@ class JSONGeneratorTest < Test::Unit::TestCase
     data = '["This is a "test" of the emergency broadcast system."]'
     json = "\"[\\\"This is a \\\"test\\\" of the emergency broadcast system.\\\"]\""
     assert_equal json, generate(data)
+    #
+    data = '\tThis is a test of the emergency broadcast system.'
+    json = "\"\\\\tThis is a test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This\tis a test of the emergency broadcast system.'
+    json = "\"This\\\\tis a test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is\ta test of the emergency broadcast system.'
+    json = "\"This is\\\\ta test of the emergency broadcast system.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is a test of the emergency broadcast\tsystem.'
+    json = "\"This is a test of the emergency broadcast\\\\tsystem.\""
+    assert_equal json, generate(data)
+    #
+    data = 'This is a test of the emergency broadcast\tsystem.\n'
+    json = "\"This is a test of the emergency broadcast\\\\tsystem.\\\\n\""
+    assert_equal json, generate(data)
   end
 
   def test_string_subclass


### PR DESCRIPTION
## Changelog

Use [bit twiddling hacks](https://graphics.stanford.edu/~seander/bithacks.html) to speed up JSON generation.

## Benchmarks from M1 Macbook Air

```
== Encoding small mixed (34 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   330.131k i/100ms
                  oj   387.021k i/100ms
Calculating -------------------------------------
                json      4.070M (± 4.7%) i/s  (245.73 ns/i) -     20.468M in   5.044536s
                  oj      3.797M (± 6.6%) i/s  (263.37 ns/i) -     18.964M in   5.018992s

Comparison:
                json:  4069584.9 i/s
                  oj:  3796948.2 i/s - same-ish: difference falls within error


== Encoding small nested array (121 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   192.904k i/100ms
                  oj   162.632k i/100ms
Calculating -------------------------------------
                json      1.943M (± 0.8%) i/s  (514.62 ns/i) -      9.838M in   5.063260s
                  oj      1.635M (± 1.3%) i/s  (611.70 ns/i) -      8.294M in   5.074536s

Comparison:
                json:  1943177.9 i/s
                  oj:  1634790.9 i/s - 1.19x  slower


== Encoding small hash (65 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   423.806k i/100ms
                  oj   457.303k i/100ms
Calculating -------------------------------------
                json      4.221M (± 1.1%) i/s  (236.93 ns/i) -     21.190M in   5.021280s
                  oj      4.550M (± 0.9%) i/s  (219.76 ns/i) -     22.865M in   5.025227s

Comparison:
                json:  4220595.9 i/s
                  oj:  4550453.2 i/s - 1.08x  faster


== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    56.000 i/100ms
                  oj    32.000 i/100ms
Calculating -------------------------------------
                json    608.762 (±13.5%) i/s    (1.64 ms/i) -      3.024k in   5.071862s
                  oj    332.758 (± 5.1%) i/s    (3.01 ms/i) -      1.664k in   5.013562s

Comparison:
                json:      608.8 i/s
                  oj:      332.8 i/s - 1.83x  slower


== Encoding mostly utf8 (5001001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json    48.000 i/100ms
                  oj    34.000 i/100ms
Calculating -------------------------------------
                json    544.068 (±13.6%) i/s    (1.84 ms/i) -      2.688k in   5.034129s
                  oj    335.560 (± 3.3%) i/s    (2.98 ms/i) -      1.700k in   5.072160s

Comparison:
                json:      544.1 i/s
                  oj:      335.6 i/s - 1.62x  slower


== Encoding integers (8009 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     7.359k i/100ms
                  oj     6.882k i/100ms
Calculating -------------------------------------
                json     72.620k (± 4.9%) i/s   (13.77 μs/i) -    367.950k in   5.081712s
                  oj     67.927k (± 4.4%) i/s   (14.72 μs/i) -    344.100k in   5.077263s

Comparison:
                json:    72620.0 i/s
                  oj:    67926.9 i/s - same-ish: difference falls within error


== Encoding activitypub.json (52595 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.912k i/100ms
                  oj     1.463k i/100ms
Calculating -------------------------------------
                json     19.541k (± 4.7%) i/s   (51.17 μs/i) -     97.512k in   5.002059s
                  oj     14.352k (± 3.4%) i/s   (69.67 μs/i) -     71.687k in   5.000899s

Comparison:
                json:    19541.4 i/s
                  oj:    14352.5 i/s - 1.36x  slower


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   105.000 i/100ms
                  oj    87.000 i/100ms
Calculating -------------------------------------
                json      1.037k (± 2.8%) i/s  (964.08 μs/i) -      5.250k in   5.065704s
                  oj    870.841 (± 2.0%) i/s    (1.15 ms/i) -      4.437k in   5.097136s

Comparison:
                json:     1037.3 i/s
                  oj:      870.8 i/s - 1.19x  slower


== Encoding twitter.json (466906 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json   197.000 i/100ms
                  oj   177.000 i/100ms
Calculating -------------------------------------
                json      1.997k (± 6.1%) i/s  (500.67 μs/i) -     10.047k in   5.052436s
                  oj      1.794k (± 2.4%) i/s  (557.52 μs/i) -      9.027k in   5.035769s

Comparison:
                json:     1997.3 i/s
                  oj:     1793.6 i/s - 1.11x  slower


== Encoding canada.json (2090234 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     1.000 i/100ms
                  oj     1.000 i/100ms
Calculating -------------------------------------
                json     10.273 (± 0.0%) i/s   (97.34 ms/i) -     52.000 in   5.062248s
                  oj     10.075 (± 0.0%) i/s   (99.26 ms/i) -     51.000 in   5.063020s

Comparison:
                json:       10.3 i/s
                  oj:       10.1 i/s - 1.02x  slower


== Encoding many #to_json calls (2701 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                json     2.224k i/100ms
                  oj     1.853k i/100ms
Calculating -------------------------------------
                json     22.282k (± 5.1%) i/s   (44.88 μs/i) -    113.424k in   5.105529s
                  oj     18.528k (± 4.0%) i/s   (53.97 μs/i) -     92.650k in   5.009527s

Comparison:
                json:    22282.5 i/s
                  oj:    18528.1 i/s - 1.20x  slower

```