### PR TITLE
Optimize 'json_parse_string' using SSE2.

### DIFF
--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -23,6 +23,16 @@ if enable_config('parser-use-simd', default=!ENV["JSON_DISABLE_SIMD"])
       end
     end
 
+    if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
+      #include <x86intrin.h>
+      int main() {
+          __m128i test = _mm_set1_epi8(32);
+          return 0;
+      }
+      SRC
+        $defs.push("-DJSON_ENABLE_SIMD")
+    end
+
     have_header('cpuid.h')
   end
 


### PR DESCRIPTION
## gcc 13.3

### Run 1
```
== Parsing activitypub.json (58160 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after   530.000 i/100ms
Calculating -------------------------------------
               after      5.726k (± 2.6%) i/s  (174.65 μs/i) -     28.620k in   5.001878s

Comparison:
              before:     4138.8 i/s
               after:     5725.7 i/s - 1.38x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after    45.000 i/100ms
Calculating -------------------------------------
               after    432.303 (± 8.8%) i/s    (2.31 ms/i) -      2.160k in   5.044614s

Comparison:
              before:      415.2 i/s
               after:      432.3 i/s - same-ish: difference falls within error


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after    21.000 i/100ms
Calculating -------------------------------------
               after    216.529 (± 3.2%) i/s    (4.62 ms/i) -      1.092k in   5.048550s

Comparison:
              before:      209.8 i/s
               after:      216.5 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after   510.000 i/100ms
Calculating -------------------------------------
               after      5.157k (± 2.9%) i/s  (193.92 μs/i) -     26.010k in   5.048160s

Comparison:
              before:     4920.7 i/s
               after:     5156.9 i/s - same-ish: difference falls within error
```

### Run 2

```
== Parsing activitypub.json (58160 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after   568.000 i/100ms
Calculating -------------------------------------
               after      5.809k (± 1.7%) i/s  (172.14 μs/i) -     29.536k in   5.085706s

Comparison:
              before:     4633.5 i/s
               after:     5809.3 i/s - 1.25x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after    47.000 i/100ms
Calculating -------------------------------------
               after    465.000 (± 2.2%) i/s    (2.15 ms/i) -      2.350k in   5.056290s

Comparison:
              before:      426.0 i/s
               after:      465.0 i/s - 1.09x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after    21.000 i/100ms
Calculating -------------------------------------
               after    207.098 (± 4.8%) i/s    (4.83 ms/i) -      1.050k in   5.082043s

Comparison:
              before:      212.5 i/s
               after:      207.1 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               after   472.000 i/100ms
Calculating -------------------------------------
               after      4.973k (± 5.9%) i/s  (201.09 μs/i) -     25.016k in   5.052435s

Comparison:
              before:     4872.1 i/s
               after:     4972.8 i/s - same-ish: difference falls within error
```

## clang-16

### Run 1
```
== Parsing activitypub.json (58160 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   610.000 i/100ms
Calculating -------------------------------------
               after      6.039k (± 2.4%) i/s  (165.59 μs/i) -     30.500k in   5.053539s

Comparison:
              before:     5346.6 i/s
               after:     6039.1 i/s - 1.13x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    47.000 i/100ms
Calculating -------------------------------------
               after    465.472 (± 2.1%) i/s    (2.15 ms/i) -      2.350k in   5.051168s

Comparison:
              before:      445.4 i/s
               after:      465.5 i/s - 1.05x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    24.000 i/100ms
Calculating -------------------------------------
               after    249.895 (± 2.8%) i/s    (4.00 ms/i) -      1.272k in   5.094197s

Comparison:
              before:      266.4 i/s
               after:      249.9 i/s - 1.07x  slower


== Parsing ohai.json (32444 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   589.000 i/100ms
Calculating -------------------------------------
               after      5.661k (± 1.9%) i/s  (176.65 μs/i) -     28.861k in   5.100224s

Comparison:
              before:     5425.3 i/s
               after:     5660.8 i/s - same-ish: difference falls within error
```

### Run 2
```
== Parsing activitypub.json (58160 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   607.000 i/100ms
Calculating -------------------------------------
               after      5.912k (± 2.2%) i/s  (169.14 μs/i) -     29.743k in   5.033413s

Comparison:
              before:     5336.5 i/s
               after:     5912.2 i/s - 1.11x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    46.000 i/100ms
Calculating -------------------------------------
               after    460.599 (± 2.4%) i/s    (2.17 ms/i) -      2.346k in   5.096212s

Comparison:
              before:      446.5 i/s
               after:      460.6 i/s - same-ish: difference falls within error


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    25.000 i/100ms
Calculating -------------------------------------
               after    255.252 (± 2.7%) i/s    (3.92 ms/i) -      1.300k in   5.097019s

Comparison:
              before:      267.6 i/s
               after:      255.3 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.3.7 (2025-01-15 revision be31f993d7) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   586.000 i/100ms
Calculating -------------------------------------
               after      5.736k (± 2.7%) i/s  (174.33 μs/i) -     28.714k in   5.009694s

Comparison:
              before:     5316.3 i/s
               after:     5736.1 i/s - 1.08x  faster
```

## clang-18

### Run 1
```
== Parsing activitypub.json (58160 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   626.000 i/100ms
Calculating -------------------------------------
               after      6.126k (± 2.4%) i/s  (163.24 μs/i) -     30.674k in   5.010235s

Comparison:
              before:     5194.5 i/s
               after:     6125.9 i/s - 1.18x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    49.000 i/100ms
Calculating -------------------------------------
               after    480.167 (± 1.9%) i/s    (2.08 ms/i) -      2.401k in   5.002133s

Comparison:
              before:      445.8 i/s
               after:      480.2 i/s - 1.08x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    27.000 i/100ms
Calculating -------------------------------------
               after    272.109 (± 3.3%) i/s    (3.67 ms/i) -      1.377k in   5.066163s

Comparison:
              before:      272.1 i/s
               after:      272.1 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   595.000 i/100ms
Calculating -------------------------------------
               after      5.887k (± 2.1%) i/s  (169.87 μs/i) -     29.750k in   5.055917s

Comparison:
              before:     5544.1 i/s
               after:     5886.9 i/s - 1.06x  faster
```

### Run 2
```
== Parsing activitypub.json (58160 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   615.000 i/100ms
Calculating -------------------------------------
               after      6.136k (± 2.4%) i/s  (162.99 μs/i) -     30.750k in   5.014873s

Comparison:
              before:     5203.1 i/s
               after:     6135.5 i/s - 1.18x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    47.000 i/100ms
Calculating -------------------------------------
               after    474.407 (± 2.3%) i/s    (2.11 ms/i) -      2.397k in   5.055209s

Comparison:
              before:      444.7 i/s
               after:      474.4 i/s - 1.07x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after    26.000 i/100ms
Calculating -------------------------------------
               after    270.705 (± 3.7%) i/s    (3.69 ms/i) -      1.378k in   5.097614s

Comparison:
              before:      271.5 i/s
               after:      270.7 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [x86_64-linux]
Warming up --------------------------------------
               after   591.000 i/100ms
Calculating -------------------------------------
               after      5.843k (± 2.8%) i/s  (171.13 μs/i) -     29.550k in   5.061128s

Comparison:
              before:     5636.6 i/s
               after:     5843.4 i/s - same-ish: difference falls within error
```